### PR TITLE
Adding a CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,10 @@ Other projects may use `main` as a default branch under specific circumstances, 
 
 - Hosted packages: those where the repository represents a hosted website.
 - Projects that would never be submodule'd/downloaded directly into a project.
-  For example, a NPM package or Javascript library.
+  For example a NPM package or Javascript library.
+- Standalone repositories that are always considered canonical/final such as
+  [.github](https://github.com/alleyinteractive/.github) or
+  [https://github.com/alleyinteractive/mantle-ci](mantle-ci).
 
 In general, projects should always reference a tagged version of a project and
 never track `develop`/`dev-develop` directly. The `develop` branch is considered

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing
+# Contributing <!-- omit in toc -->
 
 Thank you for taking the time to contribute to our open-source projects!
 Contributions are welcome and you will be fully credited.
@@ -6,21 +6,20 @@ Contributions are welcome and you will be fully credited.
 Please take the time to read and understand the contribution guide before
 creating an issue or pull request.
 
-- [Contributing](#contributing)
-  - [Code of Conduct](#code-of-conduct)
-  - [Contribution Guidelines](#contribution-guidelines)
-    - [Reporting Issues/Bugs](#reporting-issuesbugs)
-  - [Maintainership](#maintainership)
-  - [Best Practices](#best-practices)
-    - [Branch Names](#branch-names)
-    - [Coding Style](#coding-style)
-      - [WordPress Coding Standard](#wordpress-coding-standard)
-      - [Tests](#tests)
-      - [Backward Compatibility](#backward-compatibility)
-      - [Documentation](#documentation)
-      - [Compiled Assets](#compiled-assets)
-    - [Release Process](#release-process)
-      - [Releases to WordPress.org](#releases-to-wordpressorg)
+- [Code of Conduct](#code-of-conduct)
+- [Contribution Guidelines](#contribution-guidelines)
+  - [Reporting Issues/Bugs](#reporting-issuesbugs)
+- [Maintainership](#maintainership)
+- [Best Practices](#best-practices)
+  - [Branch Names](#branch-names)
+  - [Coding Style](#coding-style)
+    - [WordPress Coding Standard](#wordpress-coding-standard)
+    - [Tests](#tests)
+    - [Backward Compatibility](#backward-compatibility)
+    - [Documentation](#documentation)
+    - [Compiled Assets](#compiled-assets)
+  - [Release Process](#release-process)
+    - [Releases to WordPress.org](#releases-to-wordpressorg)
 
 ## Code of Conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,12 +48,14 @@ issue, please check for the following:
 
 ## Maintainership
 
-All repositories should have a [CODEOWNERS](codeowners) file included with a
-specified owner for the project. Preferably a team or 2+ individuals would be
-marked as "owners" who are responsible for the project. These owners are
-responsible for the maintainership of the project and controlling the scope of
-features within the said project. They shall have the final say on whether or not a
-feature request is a good fit for the scope of a project.
+All repositories should have a
+[CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+file included with a specified owner for the project. Preferably a team or 2+
+individuals would be marked as "owners" who are responsible for the project.
+These owners are responsible for the maintainership of the project and
+controlling the scope of features within the said project. They shall have the
+final say on whether or not a feature request is a good fit for the scope of a
+project.
 
 ## Best Practices
 
@@ -85,9 +87,10 @@ listed here.
 
 #### Alley Coding Standard
 
-Code must generally follow the [Alley Coding Standard](alley-coding-standards)
-which is a modified version of the [WordPress Coding
-Standards](wordpress-coding-standard).
+Code must generally follow the [Alley Coding
+Standard](https://github.com/alleyinteractive/alley-coding-standards) which is a
+modified version of the [WordPress Coding
+Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/).
 
 #### Tests
 
@@ -96,10 +99,10 @@ include tests could result in your contribution being declined.
 
 #### Backward Compatibility
 
-All contributions must be backward compatible unless a breaking change is
-being made intentionally. Breaking changes must follow [semantic
-versioning](semvar) and publish a new major release with a call out to the
-breaking change in the project's CHANGELOG.
+All contributions must be backward compatible unless a breaking change is being
+made intentionally. Breaking changes must follow [semantic
+versioning](https://semver.org/) and publish a new major release with a call out
+to the breaking change in the project's CHANGELOG.
 
 #### Documentation
 
@@ -113,23 +116,25 @@ branches. This includes minified CSS or built Javascript files. Repositories
 should use a GitHub action to produce a `*-built` branches and tags. These built
 branches/tags can be used as submodules or downloaded directly for external use.
 
-You can use a [Built Branch](built-branch) or [Built Tag](built-tag) action to
+You can use a [Built
+Branch](https://github.com/alleyinteractive/.github#built-branch) or [Built
+Tag](https://github.com/alleyinteractive/.github#built-tag) action to
 automatically compile your Composer/Node dependencies into `*-built` branches
 and tags.
 
 ### Release Process
 
 The following is a release process for all projects. All projects must follow
-[semantic versioning](semvar).
+[semantic versioning](https://semver.org/).
 
 1. Starting from the default branch of the repository, create a release branch
-   for your changes (`release/1.0.0` for example).
+   for your changes (`release/X.X.X` for example).
 2. Update the `CHANGELOG` with the release's changes. Bump the version
    referenced within the project's files, including in the `readme.txt`,
    the main plugin file, etc, to the new version.
 3. Open a pull request for your new release branch.
 4. Once the pull request is approved, merge the pull request and create a new
-   [release](releases) for the project. The release name and tag name should be
+   [release](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) for the project. The release name and tag name should be
    the version name prefixed with a `v`. For example when releasing version
    `1.0.0` of a project, the tag name and GitHub release name should be
    `v1.0.0`.
@@ -146,11 +151,3 @@ After creating a new release, projects that are published to WordPress.org
 should automatically push a new release to WordPress.org. Consider using a
 [GitHub Action](https://github.com/10up/action-wordpress-plugin-deploy) to
 automate that process.
-
-[codeowners]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-[built-branch]: https://github.com/alleyinteractive/.github#built-branch
-[built-tag]: https://github.com/alleyinteractive/.github#built-tag
-[wordpress-coding-standard]: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/
-[alley-coding-standards]: https://github.com/alleyinteractive/alley-coding-standards
-[semvar]: https://semver.org/
-[releases]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,8 +14,13 @@ creating an issue or pull request.
   - [Best Practices](#best-practices)
     - [Branch Names](#branch-names)
     - [Coding Style](#coding-style)
-    - [Compiled Assets](#compiled-assets)
+      - [WordPress Coding Standard](#wordpress-coding-standard)
+      - [Tests](#tests)
+      - [Backward Compatibility](#backward-compatibility)
+      - [Documentation](#documentation)
+      - [Compiled Assets](#compiled-assets)
     - [Release Process](#release-process)
+      - [Releases to WordPress.org](#releases-to-wordpressorg)
 
 ## Code of Conduct
 
@@ -25,18 +30,18 @@ community approachable and respectable.
 ## Contribution Guidelines
 
 Contributions to projects can be in the form of bug reports or feature requests
-via issues or pull requests. Pull requests are preferred method of contribution
-to a project.
+via issues or pull requests. Pull requests are the preferred method of
+contribution to a project.
 
 ### Reporting Issues/Bugs
 
-Issues are the best way to file a bug report to a project. Before filing an
+Issues are the best way to file a bug report for a project. Before filing an
 issue, please check for the following:
 
 - Attempt to replicate your problem to ensure it can be repeated and isn't
   coincidental.
 - Ensure that your feature request is within the scope of the project. For
-  example, please don't suggest to add Drupal support to a WordPress plugin. If
+  example, please don't suggest adding Drupal support to a WordPress plugin. If
   you are unsure, try making a discussion post in the project to ask the project
   maintainers.
 - Search the repository for an existing issue/pull request to your issue/feature
@@ -44,12 +49,104 @@ issue, please check for the following:
 
 ## Maintainership
 
+All repositories should have a [CODEOWNERS](codeowners) file included with a
+specified owner for the project. Preferably a team or 2+ individuals would be
+marked as "owners" who are responsible for the project. These owners are
+responsible for the maintainership of the project and controlling the scope of
+features within the said project. They shall have the final say on whether or not a
+feature request is a good fit for the scope of a project.
+
 ## Best Practices
+
+The following are best practices that we strive for in all of our projects. A
+project may override these where it makes sense. The respective project should
+have an updated `CONTRIBUTING.md` included with information about best practices
+for the project.
 
 ### Branch Names
 
+The default branch for repositories is `trunk`. Always work from the `trunk`
+branch and open up pull requests against it.
+
+Projects should always reference a tagged version of a project and never track
+`trunk`/`dev-trunk`. The `trunk` branch is considered 'nightly' or 'unstable' at
+all times and is subject to change without notice. Releases that follow the
+[release process](#release-process) should always be backward compatible and
+well documented via a `CHANGELOG`.
+
 ### Coding Style
 
-### Compiled Assets
+If the project maintainer has any additional requirements, you will find them
+listed here.
+
+#### WordPress Coding Standard
+
+Code must generally follow the [WordPress Coding
+Standard](wordpress-coding-standard). Our projects follow the standards via a
+[PHPCS ruleset](phpcs-ruleset) with some modifications from core to allow for
+some flexibility.
+
+#### Tests
+
+Contributions to projects should have tests associated with them. Failure to
+include tests could result in your contribution being declined.
+
+#### Backward Compatibility
+
+All contributions must be backward compatible unless a breaking change is
+being made intentionally. Breaking changes must follow [semantic
+versioning](semvar) and publish a new major release with a call out to the
+breaking change in the project's CHANGELOG.
+
+#### Documentation
+
+Ensure that the `README.md`, `CHANGELOG`, and any other documentation are
+up-to-date with any changes made.
+
+#### Compiled Assets
+
+Repositories should not contain compiled/built assets within their main
+branches. This includes minified CSS or built Javascript files. Repositories
+should use a GitHub action to produce a `*-built` branches and tags. These built
+branches/tags can be used as submodules or downloaded directly for external use.
+
+You can use a [Built Branch](built-branch) or [Built Tag](built-tag) action to
+automatically compile your Composer/Node dependencies into `*-built` branches
+and tags.
 
 ### Release Process
+
+The following is a release process for all projects. All projects must follow
+[semantic versioning](semvar).
+
+1. Starting from the default branch of the repository, create a release branch
+   for your changes (`release/1.0.0` for example).
+2. Update the `CHANGELOG` with the release's changes. Bump the version
+   referenced in the project to the new version, including in the `readme.txt`,
+   the main plugin file, etc.
+3. Create a pull request for your new release version.
+4. Once approved, merge the pull request and create a new [release](releases)
+   for the project. The tag name and release name should be the version name
+   prefixed with a `v`. For example when releasing version `1.0.0` of a
+   project, the tag name and GitHub release name should be `v1.0.0`.
+
+   The description of the release should be the release notes from the
+   `CHANGELOG`.
+5. If applicable, check to ensure that the `*-built` tag and branch of your
+   project were properly compiled via GitHub actions (see [compiled assets](#compiled-assets)).
+6. You're done, celebrate! 🎉
+
+#### Releases to WordPress.org
+
+After creating a new release, projects that are published to WordPress.org
+should automatically push a new release to WordPress.org. Consider using a
+[GitHub Action](https://github.com/10up/action-wordpress-plugin-deploy) to
+automate that process.
+
+[codeowners]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+[built-branch]: https://github.com/alleyinteractive/.github#built-branch
+[built-tag]: https://github.com/alleyinteractive/.github#built-tag
+[wordpress-coding-standard]: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/
+[phpcs-rulset]: https://github.com/alleyinteractive/alley-coding-standards
+[semvar]: https://semver.org/
+[releases]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ creating an issue or pull request.
 - [Best Practices](#best-practices)
   - [Branch Names](#branch-names)
   - [Coding Style](#coding-style)
-    - [WordPress Coding Standard](#wordpress-coding-standard)
+    - [Alley Coding Standard](#alley-coding-standard)
     - [Tests](#tests)
     - [Backward Compatibility](#backward-compatibility)
     - [Documentation](#documentation)
@@ -78,12 +78,11 @@ well documented via a `CHANGELOG`.
 If the project maintainer has any additional requirements, you will find them
 listed here.
 
-#### WordPress Coding Standard
+#### Alley Coding Standard
 
-Code must generally follow the [WordPress Coding
-Standard](wordpress-coding-standard). Our projects follow the standards via a
-[PHPCS ruleset](phpcs-ruleset) with some modifications from the core standards
-to allow for some added flexibility.
+Code must generally follow the [Alley Coding Standard](alley-coding-standards)
+which is a modified version of the [WordPress Coding
+Standards](wordpress-coding-standard).
 
 #### Tests
 
@@ -147,6 +146,6 @@ automate that process.
 [built-branch]: https://github.com/alleyinteractive/.github#built-branch
 [built-tag]: https://github.com/alleyinteractive/.github#built-tag
 [wordpress-coding-standard]: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/
-[phpcs-rulset]: https://github.com/alleyinteractive/alley-coding-standards
+[alley-coding-standards]: https://github.com/alleyinteractive/alley-coding-standards
 [semvar]: https://semver.org/
 [releases]: https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,14 +64,19 @@ for the project.
 
 ### Branch Names
 
-The default branch for repositories is `trunk`. Always work from the `trunk`
-branch and open up pull requests against it.
+The default branch for open-source repositories is `develop`. Always work from
+the `develop` branch and open up pull requests against it.
+
+The default branch name of `develop` only applies to 'package' repositories that
+have the intended purpose of being distributed in a standalone
+plugin/library/framework/etc. Hosted packages, those where the repository
+represents a hosted website, should use `main` as a default branch name.
 
 Projects should always reference a tagged version of a project and never track
-`trunk`/`dev-trunk`. The `trunk` branch is considered 'nightly' and unstable at
-all times and is subject to change without notice. Releases that follow the
-[release process](#release-process) should always be backward compatible and
-well documented via a `CHANGELOG`.
+`develop`/`dev-develop`. The `develop` branch is considered 'nightly' and
+unstable at all times and is subject to change without notice. Releases that
+follow the [release process](#release-process) should always be backward
+compatible and well documented via a `CHANGELOG`.
 
 ### Coding Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ The default branch for repositories is `trunk`. Always work from the `trunk`
 branch and open up pull requests against it.
 
 Projects should always reference a tagged version of a project and never track
-`trunk`/`dev-trunk`. The `trunk` branch is considered 'nightly' or 'unstable' at
+`trunk`/`dev-trunk`. The `trunk` branch is considered 'nightly' and unstable at
 all times and is subject to change without notice. Releases that follow the
 [release process](#release-process) should always be backward compatible and
 well documented via a `CHANGELOG`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,8 @@ listed here.
 
 Code must generally follow the [WordPress Coding
 Standard](wordpress-coding-standard). Our projects follow the standards via a
-[PHPCS ruleset](phpcs-ruleset) with some modifications from core to allow for
-some flexibility.
+[PHPCS ruleset](phpcs-ruleset) with some modifications from the core standards
+to allow for some added flexibility.
 
 #### Tests
 
@@ -121,13 +121,14 @@ The following is a release process for all projects. All projects must follow
 1. Starting from the default branch of the repository, create a release branch
    for your changes (`release/1.0.0` for example).
 2. Update the `CHANGELOG` with the release's changes. Bump the version
-   referenced in the project to the new version, including in the `readme.txt`,
-   the main plugin file, etc.
-3. Create a pull request for your new release version.
-4. Once approved, merge the pull request and create a new [release](releases)
-   for the project. The tag name and release name should be the version name
-   prefixed with a `v`. For example when releasing version `1.0.0` of a
-   project, the tag name and GitHub release name should be `v1.0.0`.
+   referenced within the project's files, including in the `readme.txt`,
+   the main plugin file, etc, to the new version.
+3. Open a pull request for your new release branch.
+4. Once the pull request is approved, merge the pull request and create a new
+   [release](releases) for the project. The release name and tag name should be
+   the version name prefixed with a `v`. For example when releasing version
+   `1.0.0` of a project, the tag name and GitHub release name should be
+   `v1.0.0`.
 
    The description of the release should be the release notes from the
    `CHANGELOG`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ creating an issue or pull request.
 
 ## Code of Conduct
 
-Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our open source
+Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our open-source
 community approachable and respectable.
 
 ## Contribution Guidelines
@@ -59,26 +59,32 @@ project.
 
 ## Best Practices
 
-The following are best practices that we strive for in all of our projects. A
-project may override these where it makes sense. The respective project should
+The following are some best practices that we strive for in all of our projects.
+A project may override these where it makes sense. The respective project should
 have an updated `CONTRIBUTING.md` included with information about best practices
 for the project.
 
 ### Branch Names
 
-The default branch for open-source repositories is `develop`. Always work from
-the `develop` branch and open up pull requests against it.
+The default branch for open-source repositories is `develop` for projects that
+can be downloaded/submoduled into a project. Always work from the `develop`
+branch and open up pull requests against it.
 
 The default branch name of `develop` only applies to 'package' repositories that
 have the intended purpose of being distributed in a standalone
-plugin/library/framework/etc. Hosted packages, those where the repository
-represents a hosted website, should use `main` as a default branch name.
+plugin/library/framework/etc.
 
-Projects should always reference a tagged version of a project and never track
-`develop`/`dev-develop`. The `develop` branch is considered 'nightly' and
-unstable at all times and is subject to change without notice. Releases that
-follow the [release process](#release-process) should always be backward
-compatible and well documented via a `CHANGELOG`.
+Other projects may use `main` as a default branch under specific circumstances, including:
+
+- Hosted packages: those where the repository represents a hosted website.
+- Projects that would never be submodule'd/downloaded directly into a project.
+  For example, a NPM package or Javascript library.
+
+In general, projects should always reference a tagged version of a project and
+never track `develop`/`dev-develop` directly. The `develop` branch is considered
+'nightly' and unstable at all times and is subject to change without notice.
+Releases that follow the [release process](#release-process) should always be
+backward compatible and well documented via a `CHANGELOG`.
 
 ### Coding Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Thank you for taking the time to contribute to our open-source projects!
+Contributions are welcome and you will be fully credited.
+
+Please take the time to read and understand the contribution guide before
+creating an issue or pull request.
+
+- [Contributing](#contributing)
+  - [Code of Conduct](#code-of-conduct)
+  - [Contribution Guidelines](#contribution-guidelines)
+    - [Reporting Issues/Bugs](#reporting-issuesbugs)
+  - [Maintainership](#maintainership)
+  - [Best Practices](#best-practices)
+    - [Branch Names](#branch-names)
+    - [Coding Style](#coding-style)
+    - [Compiled Assets](#compiled-assets)
+    - [Release Process](#release-process)
+
+## Code of Conduct
+
+Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our open source
+community approachable and respectable.
+
+## Contribution Guidelines
+
+Contributions to projects can be in the form of bug reports or feature requests
+via issues or pull requests. Pull requests are preferred method of contribution
+to a project.
+
+### Reporting Issues/Bugs
+
+Issues are the best way to file a bug report to a project. Before filing an
+issue, please check for the following:
+
+- Attempt to replicate your problem to ensure it can be repeated and isn't
+  coincidental.
+- Ensure that your feature request is within the scope of the project. For
+  example, please don't suggest to add Drupal support to a WordPress plugin. If
+  you are unsure, try making a discussion post in the project to ask the project
+  maintainers.
+- Search the repository for an existing issue/pull request to your issue/feature
+  request. Check to make sure that your issue wasn't already reported/requested.
+
+## Maintainership
+
+## Best Practices
+
+### Branch Names
+
+### Coding Style
+
+### Compiled Assets
+
+### Release Process


### PR DESCRIPTION
Introduces a CONTRIBUTING.md that all projects will inherit. The file can be overridden on a per-repository basis. Some call outs from the file:

- Adds open-source project best practices.
- Defines a process for project maintainership via `CODEOWNERS`.
- Defines a default branch name of `develop`.
- Defines a default tag name/release name format of `vX.X.X`.