### PR TITLE
Use `.deployignore` or `.distignore` if available

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,scss,css,json,yaml,yml,feature,xml}]
+indent_style = space
+indent_size = 2
+
+# Composer File
+[composer.{json,lock}]
+indent_style = space
+indent_size = 4
+
+# Dotfiles
+[.*]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/built-branch.yml
+++ b/.github/workflows/built-branch.yml
@@ -65,7 +65,12 @@ jobs:
           git config --global user.name "$GITHUB_ACTOR"
 
           rm -rf .gitignore docker_tag output.log .github
-          mv .deployignore .gitignore
+
+          if [[ -e "$GITHUB_WORKSPACE/.deployignore" ]]; then
+            mv .deployignore .gitignore
+          elif [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
+            mv .distignore .gitignore
+          fi
 
           git checkout -b $BUILT_BRANCH
 

--- a/.github/workflows/built-tag.yml
+++ b/.github/workflows/built-tag.yml
@@ -65,7 +65,12 @@ jobs:
           git config --global user.name "$GITHUB_ACTOR"
 
           rm -rf .gitignore docker_tag output.log .github
-          mv .deployignore .gitignore
+
+          if [[ -e "$GITHUB_WORKSPACE/.deployignore" ]]; then
+            mv .deployignore .gitignore
+          elif [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
+            mv .distignore .gitignore
+          fi
 
           git checkout -b $BUILT_BRANCH
 


### PR DESCRIPTION
- As titled;
- Added `.editorconfig`.

I'm not convinced that `.deployignore` should be required for this action. This action is to create a built branch, presumably for submodules, not deploy code to SVN or external tools.

Also, `.distignore` is the version that can be used with `wp dist-archive` (source: https://developer.wordpress.org/cli/commands/dist-archive/). 
And `.gitattributes` is also commonly used. But we are not taking it into account here.

To avoid issues, it's better to not make any of those required. And let the plugin applying the action to use any of those files.

resolves #40 