### PR TITLE
Add a Composer Command workflow

### DIFF
--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -57,6 +57,8 @@ jobs:
             exit 1
           fi
 
+          set +e
+
           # Split the command string into an array by newline
           IFS=$'\n' read -rd '' -a commands <<<"$COMPOSER_COMMANDS"
 

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -45,20 +45,8 @@ jobs:
           composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist"
           dependency-versions: ${{ inputs.dependency-versions }}
 
-      # - id: commands-to-run
-      #   shell: bash
-      #   name: Extract Commands
-      #   env:
-      #     text: ${{ inputs.command }}
-      #   run: |
-      #     text="${text//'%'/'%25'}"
-      #     text="${text//$'\n'/'%0A'}"
-      #     text="${text//$'\r'/'%0D'}"
-      #     echo "value=$text" >> $GITHUB_OUTPUT
-
       - name: Run Commands
         env:
-          # COMPOSER_COMMANDS: ${{ steps.commands-to-run.outputs.value }}
           COMPOSER_COMMANDS: ${{ inputs.command }}
         run: |
           echo "Commands to run: $COMPOSER_COMMANDS"
@@ -69,8 +57,8 @@ jobs:
             exit 1
           fi
 
-          # Split the command string into an array by the %0A or newline
-          IFS='%0A' read -ra commands <<< "$COMPOSER_COMMANDS"
+          # Split the command string into an array by newline
+          IFS=$'\n' read -rd '' -a commands <<<"$COMPOSER_COMMANDS"
 
           set -e
 
@@ -79,5 +67,3 @@ jobs:
             echo "Running: composer run $command"
             composer run "$command"
           done
-
-          exit 0

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -75,8 +75,8 @@ jobs:
 
           # Run each command in the array
           for command in "${commands[@]}"; do
-            echo "Running: composer $command"
-            composer "$command"
+            echo "Running: composer run $command"
+            composer run "$command"
           done
 
           exit 0

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -57,11 +57,13 @@ jobs:
             exit 1
           fi
 
+          # Allow errors to be ignored
           set +e
 
           # Split the command string into an array by newline
           IFS=$'\n' read -rd '' -a commands <<<"$COMPOSER_COMMANDS"
 
+          # Re-enable errors causing the script to exit
           set -e
 
           # Run each command in the array

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -1,0 +1,69 @@
+name: Composer Command
+
+on:
+  workflow_call:
+    inputs:
+      command:
+        default: "test"
+        required: true
+        type: "string"
+      php:
+        default: "8.0"
+        required: false
+        type: string
+      dependency-versions:
+        default: "locked"
+        required: false
+        type: "string"
+      working-directory:
+        default: "."
+        required: false
+        type: "string"
+
+jobs:
+  tests:
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+    runs-on: ubuntu-latest
+    name: ${{ inputs.command }} PHP ${{ inputs.php }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          working-directory: ${{ inputs.working-directory }}
+          composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist"
+          dependency-versions: ${{ inputs.dependency-versions }}
+
+      - name: Run ${{ inputs.command }}
+        env:
+          COMPOSER_COMMANDS: ${{ inputs.command }}
+        run: |
+          # Ensure that Composer commands are defined
+          if [ -z "$COMPOSER_COMMANDS" ]; then
+            echo "No commands to run"
+            exit 1
+          fi
+
+          # Split the commnad string into an array by new line.
+          IFS=$'\n' read -rd '' -a commands <<< "$COMPOSER_COMMANDS"
+
+          set -e
+
+          # Run each command in the array
+          for command in "${commands[@]}"; do
+            echo "Running: composer $command"
+            composer "$command"
+          done
+
+          exit 0

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -68,8 +68,8 @@ jobs:
             exit 1
           fi
 
-          # Split the commnad string into an array by new line.
-          IFS=$'\n' read -rd '' -a commands <<< "$COMPOSER_COMMANDS"
+          # Split the command string into an array by the %0A delimiter
+          IFS='%0A' read -ra commands <<< "$COMPOSER_COMMANDS"
 
           set -e
 

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Commands
         env:
-          COMPOSER_COMMANDS: ${{ steps.set.outputs.value }}
+          COMPOSER_COMMANDS: ${{ steps.set.outputs.content }}
         run: |
           echo "Commands to run: $COMPOSER_COMMANDS"
 

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -45,9 +45,20 @@ jobs:
           composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist"
           dependency-versions: ${{ inputs.dependency-versions }}
 
+      # Set the commands as an environment variable
+      - id: set
+        shell: bash
+        env:
+          text: ${{ inputs.command }}
+        run: |
+          text="${text//'%'/'%25'}"
+          text="${text//$'\n'/'%0A'}"
+          text="${text//$'\r'/'%0D'}"
+          echo "value=$text" >> $GITHUB_OUTPUT
+
       - name: Run Commands
         env:
-          COMPOSER_COMMANDS: ${{ inputs.command }}
+          COMPOSER_COMMANDS: ${{ steps.set.outputs.value }}
         run: |
           echo "Commands to run: $COMPOSER_COMMANDS"
 

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -45,10 +45,12 @@ jobs:
           composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist"
           dependency-versions: ${{ inputs.dependency-versions }}
 
-      - name: Run ${{ inputs.command }}
+      - name: Run Commands
         env:
           COMPOSER_COMMANDS: ${{ inputs.command }}
         run: |
+          echo "Commands to run: $COMPOSER_COMMANDS"
+
           # Ensure that Composer commands are defined
           if [ -z "$COMPOSER_COMMANDS" ]; then
             echo "No commands to run"

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -45,20 +45,21 @@ jobs:
           composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist"
           dependency-versions: ${{ inputs.dependency-versions }}
 
-      - id: commands-to-run
-        shell: bash
-        name: Extract Commands
-        env:
-          text: ${{ inputs.command }}
-        run: |
-          text="${text//'%'/'%25'}"
-          text="${text//$'\n'/'%0A'}"
-          text="${text//$'\r'/'%0D'}"
-          echo "value=$text" >> $GITHUB_OUTPUT
+      # - id: commands-to-run
+      #   shell: bash
+      #   name: Extract Commands
+      #   env:
+      #     text: ${{ inputs.command }}
+      #   run: |
+      #     text="${text//'%'/'%25'}"
+      #     text="${text//$'\n'/'%0A'}"
+      #     text="${text//$'\r'/'%0D'}"
+      #     echo "value=$text" >> $GITHUB_OUTPUT
 
       - name: Run Commands
         env:
-          COMPOSER_COMMANDS: ${{ steps.commands-to-run.outputs.value }}
+          # COMPOSER_COMMANDS: ${{ steps.commands-to-run.outputs.value }}
+          COMPOSER_COMMANDS: ${{ inputs.command }}
         run: |
           echo "Commands to run: $COMPOSER_COMMANDS"
 
@@ -68,7 +69,7 @@ jobs:
             exit 1
           fi
 
-          # Split the command string into an array by the %0A delimiter
+          # Split the command string into an array by the %0A or newline
           IFS='%0A' read -ra commands <<< "$COMPOSER_COMMANDS"
 
           set -e

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -45,9 +45,9 @@ jobs:
           composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist"
           dependency-versions: ${{ inputs.dependency-versions }}
 
-      # Set the commands as an environment variable
-      - id: set
+      - id: commands-to-run
         shell: bash
+        name: Extract Commands
         env:
           text: ${{ inputs.command }}
         run: |
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Commands
         env:
-          COMPOSER_COMMANDS: ${{ steps.set.outputs.content }}
+          COMPOSER_COMMANDS: ${{ steps.commands-to-run.outputs.value }}
         run: |
           echo "Commands to run: $COMPOSER_COMMANDS"
 

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -76,6 +76,7 @@ jobs:
 
       - name: Install dependencies
         uses: ramsey/composer-install@v2
+        if: inputs.action == 'install'
         with:
           composer-options: "--no-progress --no-ansi --no-interaction --prefer-dist"
           dependency-versions: ${{ inputs.dependency-versions }}
@@ -86,7 +87,7 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 5
-          command: composer update --${{ inputs.stability }} --prefer-dist --no-interaction
+          command: composer update --prefer-dist --no-interaction
 
       - name: Test Package
         shell: bash

--- a/README.md
+++ b/README.md
@@ -304,10 +304,10 @@ on:
 jobs:
   code-quality:
     uses: alleyinteractive/.github/.github/workflows/php-composer-command.yml@main
-	with:
-	  command: |
-	    lint
-	    phpunit
+    with:
+      command: |
+        lint
+        phpunit
 ```
 
 ### PHP Code Quality

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following workflows are available to use:
 - [Dependabot Auto Merge](#dependabot-auto-merge)
 - [Dependabot Auto Approve](#dependabot-auto-approve)
 - [Node Tests](#node-tests)
+- [PHP Composer Script](#php-composer-script)
 - [PHP Code Quality](#php-code-quality)
 - [PHP Coding Standards](#php-coding-standards)
 - [PHP Tests](#php-tests)
@@ -258,6 +259,55 @@ on:
 jobs:
   coding-standards:
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
+```
+
+### PHP Composer Script
+
+Run a set of Composer scripts against your project. Assumes that `composer run
+<command>` will run your tests. Supports multiple commands.
+
+#### Inputs
+
+> Specify using `with` keyword.
+
+##### `command`
+
+- Specify the Composer command to use for testing.
+- Accepts a string.
+- Required.
+
+##### `php`
+
+- Specify the PHP version to use.
+- Accepts a number.
+- Defaults to `8.0`.
+
+##### `working-directory`
+
+- Specify the working directory to use.
+- Accepts a string.
+- Defaults to the root of the repository.
+
+#### Usage
+
+```yml
+name: Composer Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  code-quality:
+    uses: alleyinteractive/.github/.github/workflows/php-composer-command.yml@main
+	with:
+	  command: |
+	    lint
+	    phpunit
 ```
 
 ### PHP Code Quality

--- a/README.md
+++ b/README.md
@@ -18,16 +18,19 @@ continuous integration tests with Github Actions.
 
 The following workflows are available to use:
 
-- [Built Branch](#built-branch)
-- [Built Tag](#built-tag)
-- [Dependabot Auto Merge](#dependabot-auto-merge)
-- [Dependabot Auto Approve](#dependabot-auto-approve)
-- [Node Tests](#node-tests)
-- [PHP Composer Script](#php-composer-script)
-- [PHP Code Quality](#php-code-quality)
-- [PHP Coding Standards](#php-coding-standards)
-- [PHP Tests](#php-tests)
-- [Deploy to Remote Repository](#deploy-to-remote-repository)
+- Built Branches/Tags and Other Deployment Workflows
+  - [Built Branch](#built-branch)
+  - [Built Tag](#built-tag)
+  - [Deploy to Remote Repository](#deploy-to-remote-repository)
+- Dependabot Management
+  - [Dependabot Auto Merge](#dependabot-auto-merge)
+  - [Dependabot Auto Approve](#dependabot-auto-approve)
+- Testing Workflows
+  - [Node Tests](#node-tests)
+  - [PHP Composer Script](#php-composer-script)
+  - [PHP Tests](#php-tests)
+  - [PHP Code Quality](#php-code-quality)
+  - [PHP Coding Standards](#php-coding-standards)
 
 ### Built Branch
 
@@ -215,56 +218,13 @@ jobs:
     uses: alleyinteractive/.github/.github/workflows/node-tests.yml@main
 ```
 
-### PHP Coding Standards
-
-Run `phpcs` tests against your project. Assumes that `composer run phpcs` will
-run your tests.
-
-#### Inputs
-
-> Specify using `with` keyword.
-
-##### `php`
-
-- Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
-
-##### `dependency-versions`
-
-- Allows you to select whether the job should install the locked, highest, or
-  lowest versions of Composer dependencies.
-- Accepts a string: `locked`, `highest`, or `lowest`.
-- Defaults to `locked`.
-
-##### `working-directory`
-
-- Specify the working directory to use.
-- Accepts a string.
-- Defaults to the root of the repository.
-
-#### Usage
-
-```yml
-name: Coding Standards
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  schedule:
-    - cron: '0 0 * * *'
-
-jobs:
-  coding-standards:
-    uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
-```
-
 ### PHP Composer Script
 
 Run a set of Composer scripts against your project. Assumes that `composer run
-<command>` will run your tests. Supports multiple commands.
+<command>` will run your tests. Supports multiple commands with a multi-line
+`command` input.
+
+> Note: This workflow does not setup MySQL for testing. Use the [PHP Tests](#php-tests) workflow for that.
 
 #### Inputs
 
@@ -310,59 +270,7 @@ jobs:
         phpunit
 ```
 
-### PHP Code Quality
-
-Run `phpstan` tests against your project. Assumes that `composer run phpstan` will
-run your tests.
-
-#### Inputs
-
-> Specify using `with` keyword.
-
-##### `command`
-
-- Specify the Composer command to use for testing.
-- Accepts a string.
-- Defaults to `phpstan`.
-
-##### `php`
-
-- Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
-
-##### `dependency-versions`
-
-- Allows you to select whether the job should install the locked, highest, or
-  lowest versions of Composer dependencies.
-- Accepts a string: `locked`, `highest`, or `lowest`.
-- Defaults to `locked`.
-
-##### `working-directory`
-
-- Specify the working directory to use.
-- Accepts a string.
-- Defaults to the root of the repository.
-
-#### Usage
-
-```yml
-name: Code Quality
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  schedule:
-    - cron: '0 0 * * *'
-
-jobs:
-  code-quality:
-    uses: alleyinteractive/.github/.github/workflows/php-code-quality.yml@main
-```
-
-### PHP Tests
+### PHP Tests with MySQL
 
 Run PHPUnit tests against your project. Installs and configures MySQL for
 WordPress unit testing. Assumes that `composer run phpunit` will run your unit
@@ -560,4 +468,106 @@ jobs:
       exclude_list: '.git, pantheon-mu-plugin'
     secrets:
       REMOTE_REPO_SSH_KEY: ${{ secrets.REMOTE_REPO_SSH_KEY }}
+```
+
+### PHP Code Quality
+
+Run `phpstan` tests against your project. Assumes that `composer run phpstan` will
+run your tests.
+
+> ℹ️ Note: This action is deprecated in favor of the [PHP Composer Script](#php-composer-script) action.
+
+#### Inputs
+
+> Specify using `with` keyword.
+
+##### `command`
+
+- Specify the Composer command to use for testing.
+- Accepts a string.
+- Defaults to `phpstan`.
+
+##### `php`
+
+- Specify the PHP version to use.
+- Accepts a number.
+- Defaults to `8.0`.
+
+##### `dependency-versions`
+
+- Allows you to select whether the job should install the locked, highest, or
+  lowest versions of Composer dependencies.
+- Accepts a string: `locked`, `highest`, or `lowest`.
+- Defaults to `locked`.
+
+##### `working-directory`
+
+- Specify the working directory to use.
+- Accepts a string.
+- Defaults to the root of the repository.
+
+#### Usage
+
+```yml
+name: Code Quality
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  code-quality:
+    uses: alleyinteractive/.github/.github/workflows/php-code-quality.yml@main
+```
+
+### PHP Coding Standards
+
+Run `phpcs` tests against your project. Assumes that `composer run phpcs` will
+run your tests.
+
+> ℹ️ Note: This action is deprecated in favor of the [PHP Composer Script](#php-composer-script) action.
+
+#### Inputs
+
+> Specify using `with` keyword.
+
+##### `php`
+
+- Specify the PHP version to use.
+- Accepts a number.
+- Defaults to `8.0`.
+
+##### `dependency-versions`
+
+- Allows you to select whether the job should install the locked, highest, or
+  lowest versions of Composer dependencies.
+- Accepts a string: `locked`, `highest`, or `lowest`.
+- Defaults to `locked`.
+
+##### `working-directory`
+
+- Specify the working directory to use.
+- Accepts a string.
+- Defaults to the root of the repository.
+
+#### Usage
+
+```yml
+name: Coding Standards
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  coding-standards:
+    uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following workflows are available to use:
 - Testing Workflows
   - [Node Tests](#node-tests)
   - [PHP Composer Script](#php-composer-script)
-  - [PHP Tests](#php-tests)
+  - [PHP Tests with MySQL](#php-tests-with-mysql)
   - [PHP Code Quality](#php-code-quality)
   - [PHP Coding Standards](#php-coding-standards)
 
@@ -224,7 +224,8 @@ Run a set of Composer scripts against your project. Assumes that `composer run
 <command>` will run your tests. Supports multiple commands with a multi-line
 `command` input.
 
-> Note: This workflow does not setup MySQL for testing. Use the [PHP Tests](#php-tests) workflow for that.
+> Note: This workflow does not setup MySQL for testing. Use the
+> [PHP Tests with MySQL](#php-tests-with-mysql) workflow for that.
 
 #### Inputs
 
@@ -262,7 +263,7 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  code-quality:
+  composer-lint-phpunit:
     uses: alleyinteractive/.github/.github/workflows/php-composer-command.yml@main
     with:
       command: |


### PR DESCRIPTION
- Adds a single Composer Command workflow to replace the two Composer-based workflows we already have. Folks can now run one or more `composer run <script>` commands through their action.
- Marks two workflows as deprecated in favor of this new one for simplicity. Reorganizes the README to be broken down by section.