### PR TITLE
Allow the working directory to be modified

### DIFF
--- a/.github/workflows/built-branch.yml
+++ b/.github/workflows/built-branch.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       php:
-        default: 8.0
+        default: "8.0"
         required: false
-        type: number
+        type: string
       node:
         default: 16
         required: false

--- a/.github/workflows/built-tag.yml
+++ b/.github/workflows/built-tag.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       php:
-        default: 8.0
+        default: "8.0"
         required: false
-        type: number
+        type: string
       node:
         default: 16
         required: false

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Check if the plugin has front-end assets
         shell: bash

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -31,9 +31,16 @@ on:
         default: true
         required: false
         type: boolean
+      working-directory:
+        default: "."
+        required: false
+        type: "string"
 
 jobs:
   npm-ci:
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
     name: Install, build, and test
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/php-code-quality.yml
+++ b/.github/workflows/php-code-quality.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -4,9 +4,9 @@ on:
   workflow_call:
     inputs:
       php:
-        default: 8.0
+        default: "8.0"
         required: false
-        type: number
+        type: string
       dependency-versions:
         default: "locked"
         required: false

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -12,9 +12,9 @@ on:
         required: false
         type: "string"
       php:
-        default: 8.0
+        default: "8.0"
         required: false
-        type: number
+        type: string
       os:
         default: "ubuntu-latest"
         required: false

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -62,6 +62,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Create a `*-built` version of a branch for use in submodules.
 ##### `php`
 
 - Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
+- Accepts a string.
+- Defaults to `'8.0'`.
 
 ##### `node`
 
@@ -79,8 +79,8 @@ Create a `*-built` version of a tag for use in submodules.
 ##### `php`
 
 - Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
+- Accepts a string.
+- Defaults to `'8.0'`.
 
 ##### `node`
 
@@ -246,8 +246,8 @@ Run a set of Composer scripts against your project. Assumes that `composer run
 ##### `php`
 
 - Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
+- Accepts a string.
+- Defaults to `'8.0'`.
 
 ##### `working-directory`
 
@@ -308,8 +308,8 @@ tests.
 ##### `php`
 
 - Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
+- Accepts a string.
+- Defaults to `'8.0'`.
 
 ##### `wordpress`
 
@@ -497,8 +497,8 @@ run your tests.
 ##### `php`
 
 - Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
+- Accepts a string.
+- Defaults to `'8.0'`.
 
 ##### `dependency-versions`
 
@@ -545,8 +545,8 @@ run your tests.
 ##### `php`
 
 - Specify the PHP version to use.
-- Accepts a number.
-- Defaults to `8.0`.
+- Accepts a string.
+- Defaults to `'8.0'`.
 
 ##### `dependency-versions`
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,12 @@ npm run build
 - Accepts a boolean.
 - Defaults to `true`.
 
+##### `working-directory`
+
+- Specify the working directory to use.
+- Accepts a string.
+- Defaults to the root of the repository.
+
 #### Usage
 
 ```yml


### PR DESCRIPTION
- Allow the working directory to be modified on the Node test.
- Move all PHP versions to a string to prevent them from being handled as a floating point number (`10.10` would be converted to `10.1` -- making it a string fixes that). Tested in https://github.com/alleyinteractive/create-wordpress-plugin/pull/239 that this won't break existing projects.