### PR TITLE
Cache the CACHEDIR directory

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -65,6 +65,14 @@ jobs:
         with:
           submodules: 'recursive'
 
+      - name: Setup Cache
+        uses: actions/cache@v3
+        with:
+          path: /tmp/test-cache
+          key: ${{ runner.os }}-composer-${{ inputs.php }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:


### PR DESCRIPTION
Cache the `CACHEDIR` directory. This directory is used by https://github.com/alleyinteractive/mantle-ci/blob/develop/install-wp-tests.sh to download and cache external files during the CI process, such as the latest version of WordPress and WordPress/plugin ZIP files.