### PR TITLE
"push to -built tags/branch" actually remove `.gitignore` files

### DIFF
--- a/.github/workflows/built-branch.yml
+++ b/.github/workflows/built-branch.yml
@@ -72,6 +72,8 @@ jobs:
             mv .distignore .gitignore
           fi
 
+          git ls-files -i -c --exclude-standard | xargs git rm --cached
+
           git checkout -b $BUILT_BRANCH
 
           git add -A && git commit -m "Changes from $GITHUB_SHA"

--- a/.github/workflows/built-tag.yml
+++ b/.github/workflows/built-tag.yml
@@ -72,6 +72,8 @@ jobs:
             mv .distignore .gitignore
           fi
 
+          git ls-files -i -c --exclude-standard | xargs git rm --cached
+
           git checkout -b $BUILT_BRANCH
 
           git add -A && git commit -m "Built changes for $TAG_NAME"


### PR DESCRIPTION
This pull request is about untracking (remove from version control) files that are ignored according to the `.gitignore` rules.

That means when creating a `-built` branch, the files removed inside `.deployignore` or `.distignore` are actually "removed" from the built branch.

Currently, even though they are ignored, the files persist in the `-built` branch. See an example here: https://github.com/alleyinteractive/byline-manager/tree/production-built

fixes #47 