### PR TITLE
Limit all reusable workflows to 10 minutes

### DIFF
--- a/.github/workflows/built-branch.yml
+++ b/.github/workflows/built-branch.yml
@@ -16,6 +16,7 @@ jobs:
   built-branch:
     name: Built Branch
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/built-tag.yml
+++ b/.github/workflows/built-tag.yml
@@ -16,6 +16,7 @@ jobs:
   built-tag:
     name: Create Built Release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata

--- a/.github/workflows/deploy-to-remote-repository.yml
+++ b/.github/workflows/deploy-to-remote-repository.yml
@@ -39,6 +39,7 @@ jobs:
   deploy:
     runs-on: ${{ inputs.os }}
     name: "Syncing ${{ inputs.base_directory }} to ${{ inputs.remote_repo }}@${REMOTE_BRANCH}: ${{ inputs.destination_directory }}"
+    timeout-minutes: 10
 
     env:
       GIT_SSH_COMMAND: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i ~/.ssh/private_key

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -37,12 +37,13 @@ on:
         type: "string"
 
 jobs:
-  npm-ci:
+  node-tests:
     defaults:
       run:
         working-directory: ${{ inputs.working-directory }}
     name: Install, build, and test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
         if: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/php-code-quality.yml
+++ b/.github/workflows/php-code-quality.yml
@@ -26,6 +26,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: ${{ inputs.command }} PHP ${{ inputs.php }}
     steps:
       - name: Checkout code

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -22,6 +22,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: phpcs ${{ inputs.php }}
     steps:
       - name: Checkout code

--- a/.github/workflows/php-composer-command.yml
+++ b/.github/workflows/php-composer-command.yml
@@ -26,6 +26,7 @@ jobs:
       run:
         working-directory: ${{ inputs.working-directory }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     name: ${{ inputs.command }} PHP ${{ inputs.php }}
     steps:
       - name: Checkout code

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -35,6 +35,7 @@ on:
 jobs:
   test:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 10
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
By default, GitHub actions timeout after 360 minutes. This default feels too large and can lead to long-running workflows that should have timed out well before 360 minutes have been reached.