### PR TITLE
Read the built version from the plugin header

### DIFF
--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -86,7 +86,7 @@ jobs:
     if : ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository }} != 'alleyinteractive/create-wordpress-plugin'
     runs-on: ubuntu-latest
     env:
-      RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}"
+      RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}-${{ github.run_number }}"
       VERSION_NAME: ${{ needs.extract-version.outputs.package_version }}
       VERSION_TAG: ${{ needs.extract-version.outputs.tag_name }}
     steps:

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -33,16 +33,14 @@ jobs:
           PACKAGE_VERSION="null"
           PLUGIN_NAME=$(basename $(pwd))
 
-          echo "PLUGIN_NAME: $PLUGIN_NAME"
-
           extract-version() {
-            echo grep -iE "^\s\* Version:" "$1" | awk -F' ' '{print $NF}'
+            grep -E "Version: [0-9]+\.[0-9]+\.[0-9]+" $1 | grep -Eo "[0-9]+\.[0-9]+\.[0-9]+" | head -1
           }
 
           if [ -f "$PLUGIN_NAME.php" ]; then
             PACKAGE_VERSION=$(extract-version "$PLUGIN_NAME.php")
-          elif [ -f plugin.php ]; then
-            PACKAGE_VERSION=$(extract-version plugin.php)
+          elif [ -f "plugin.php" ]; then
+            PACKAGE_VERSION=$(extract-version "plugin.php")
           fi
 
           if [ -f composer.json ] && [ "$PACKAGE_VERSION" = "null" ]; then
@@ -52,6 +50,16 @@ jobs:
           if [ -f package.json ] && [ "$PACKAGE_VERSION" = "null" ]; then
             PACKAGE_VERSION=$(cat package.json | jq -r '.version')
           fi
+
+          # Validate that we have a semver version number
+          if [ "$PACKAGE_VERSION" != "null" ]; then
+            if ! [[ "$PACKAGE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+              echo "Invalid version number: $PACKAGE_VERSION"
+              exit 1
+            fi
+          fi
+
+          echo "PACKAGE_VERSION: $PACKAGE_VERSION"
 
           if [ $PACKAGE_VERSION = "null" ] || [ -z $PACKAGE_VERSION ]; then
             echo "package_version=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -33,6 +33,8 @@ jobs:
           PACKAGE_VERSION="null"
           PLUGIN_NAME=$(basename $(pwd))
 
+          echo "PLUGIN_NAME: $PLUGIN_NAME"
+
           extract-version() {
             echo grep -iE "^\s\* Version:" "$1" | awk -F' ' '{print $NF}'
           }

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -21,6 +21,7 @@ jobs:
       package_version: ${{ steps.extract-version.outputs.package_version }}
       tag_exists: ${{ steps.check-tag.outputs.tag_exists }}
       tag_name: ${{ steps.tag-name.outputs.tag_name }}
+    if: ${{ github.repository }} != 'alleyinteractive/create-wordpress-plugin'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,8 +31,19 @@ jobs:
         id: extract-version
         run: |
           PACKAGE_VERSION="null"
+          PLUGIN_NAME=$(basename $(pwd))
 
-          if [ -f composer.json ]; then
+          extract-version() {
+            echo grep -iE "^\s\* Version:" "$1" | awk -F' ' '{print $NF}'
+          }
+
+          if [ -f "$PLUGIN_NAME.php" ]; then
+            PACKAGE_VERSION=$(extract-version "$PLUGIN_NAME.php")
+          elif [ -f plugin.php ]; then
+            PACKAGE_VERSION=$(extract-version plugin.php)
+          fi
+
+          if [ -f composer.json ] && [ "$PACKAGE_VERSION" = "null" ]; then
             PACKAGE_VERSION=$(cat composer.json | jq -r '.version')
           fi
 
@@ -69,7 +81,7 @@ jobs:
 
   build-and-release:
     needs: extract-version
-    if : ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true'
+    if : ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository }} != 'alleyinteractive/create-wordpress-plugin'
     runs-on: ubuntu-latest
     env:
       RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}"

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ jobs:
 
 ### Built Releases
 
-Create built releases of a project based on the `composer.json`/`package.json`
-version constraint. When the `version` field is updated in either file, the
-action will build the project, push a new tag up with the version, and create a
+Create built releases of a project based on the WordPress plugin `Stable Tag`
+header and falling back to the `version` property in either `composer.json` or
+`package.json`. When the version is updated in either file, the action
+will build the project, push a new tag up with the version, and create a
 release. Optionally, the release can be drafted or published.
 
 The most common use of this workflow is for WordPress plugins or other packages


### PR DESCRIPTION
Adds support for reading the version of the plugin from the plugin's header file versus only from `composer.json`/`package.json`.