### PR TITLE
Callout PSR-4 standards for unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,8 @@ Standard](https://github.com/alleyinteractive/alley-coding-standards) which is a
 modified version of the [WordPress Coding
 Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/).
 
-One exception to this is unit tests which follow Alley Coding Standards but are
-stored in PSR-4 compliant file paths. For example, a class file created with a
+One exception to this are unit tests which follow Alley Coding Standards but are
+stored in PSR-4-compliant file paths. For example, a class file created with a
 file path of `src/feature/class-example.php` would have a unit test located at
 `tests/Feature/ExampleTest.php`. Alley Coding Standards will be evolving to
 embrace PSR-4 in the future for more of the codebase, but for now, this exception

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ modified version of the [WordPress Coding
 Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/).
 
 One exception to this are unit tests which follow Alley Coding Standards but are
-stored in PSR-4-compliant file paths. For example, a class file created with a
+stored in [PSR-4-compliant file paths](https://www.php-fig.org/psr/psr-4/). For example, a class file created with a
 file path of `src/feature/class-example.php` would have a unit test located at
 `tests/Feature/ExampleTest.php`. Alley Coding Standards will be evolving to
 embrace PSR-4 in the future for more of the codebase, but for now, this exception

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,13 @@ Standard](https://github.com/alleyinteractive/alley-coding-standards) which is a
 modified version of the [WordPress Coding
 Standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/).
 
+One exception to this is unit tests which follow Alley Coding Standards but are
+stored in PSR-4 compliant file paths. For example, a class file created with a
+file path of `src/feature/class-example.php` would have a unit test located at
+`tests/Feature/ExampleTest.php`. Alley Coding Standards will be evolving to
+embrace PSR-4 in the future for more of the codebase, but for now, this exception
+is in place only for unit tests.
+
 #### Tests
 
 Contributions to projects should have tests associated with them. Failure to


### PR DESCRIPTION
Call out the new standards for unit tests which are written as PSR-4 compliant code.