### PR TITLE
Rebuilding the release workflow

### DIFF
--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: true
         type: boolean
-      npm_command:
+      cmd:
         description: 'The npm command to run that will build the assets'
         required: false
         default: 'build'
@@ -167,8 +167,8 @@ jobs:
         run: |
           [ -f package-lock.json ] && npm ci || npm i
 
-      - name: Run npm build
-        run: npm run ${{ inputs.npm_command }}
+      - name: Run npm command
+        run: npm run ${{ inputs.cmd }}
 
       - name: Push to ${{ needs.extract-version.outputs.branch }}-built branch
         shell: bash

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -96,6 +96,7 @@ jobs:
         id: branch-name
 
       - name: Check if this is the built branch
+        if: ${{ steps.extract-version.outputs.package_version }} != 'false'
         id: is-built-branch
         shell: bash
         run: |
@@ -114,7 +115,7 @@ jobs:
 
       - name: Check if the version already exists as a tag
         id: check-tag
-        if: ${{ steps.tag-name.outputs.tag_name }}
+        if: ${{ steps.extract-version.outputs.package_version }} != 'false' && ${{ steps.tag-name.outputs.tag_name }}
         run: |
           echo "Checking tag: ${{ steps.tag-name.outputs.tag_name }}"
 
@@ -129,6 +130,7 @@ jobs:
 
       - name: Check if the plugin has front-end assets
         shell: bash
+        if: ${{ steps.extract-version.outputs.package_version }} != 'false'
         id: has_node_assets
         run: |
           [[ -f package.json ]] && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -113,9 +113,6 @@ jobs:
         id: check-tag
         if: steps.extract-version.outputs.package_version != 'false' && steps.tag-name.outputs.tag_name
         run: |
-          echo "Checking tag: ${{ steps.tag-name.outputs.tag_name }}"
-
-          # Check if the tag exists
           if [ -z "$(git tag -l ${{ steps.tag-name.outputs.tag_name }})" ]; then
             echo "tag_exists=false" >> $GITHUB_OUTPUT
           else
@@ -221,8 +218,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "PREVIOUS_TAG_VERSION: $PREVIOUS_TAG_VERSION"
-
           if [ "$PREVIOUS_TAG_VERSION" == "false" ]; then
             if [[ $DRAFT_RELEASE == "true" ]]; then
               gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --latest

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -191,7 +191,7 @@ jobs:
 
           git checkout -b $BUILT_BRANCH
 
-          git add -A && git commit -m "Built changes from $CURRENT_BRANCH"
+          git add -A && git commit -m "Built changes from $CURRENT_BRANCH: $GITHUB_SHA"
           git push --force -u origin "${BUILT_BRANCH}"
 
       - name: Create tag and release for built branch

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -37,7 +37,7 @@ jobs:
       package_version: ${{ steps.extract-version.outputs.package_version }}
       tag_exists: ${{ steps.check-tag.outputs.tag_exists }}
       tag_name: ${{ steps.tag-name.outputs.tag_name }}
-    if: ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+    if: github.repository != 'alleyinteractive/create-wordpress-plugin'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -95,8 +95,7 @@ jobs:
         run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
         id: branch-name
 
-      - name: Check if this is the built branch
-        if: ${{ steps.extract-version.outputs.package_version != false }}
+      - name: Check if this is a built branch
         id: is-built-branch
         shell: bash
         run: |
@@ -110,12 +109,12 @@ jobs:
 
       - name: Compile the tag name from the version
         id: tag-name
-        if: ${{ steps.extract-version.outputs.package_version != false }}
+        if: steps.extract-version.outputs.package_version != 'false'
         run: echo "tag_name=v${{ steps.extract-version.outputs.package_version }}" >> $GITHUB_OUTPUT
 
       - name: Check if the version already exists as a tag
         id: check-tag
-        if: ${{ steps.extract-version.outputs.package_version != false }} && ${{ steps.tag-name.outputs.tag_name }}
+        if: steps.extract-version.outputs.package_version != 'false' && steps.tag-name.outputs.tag_name
         run: |
           echo "Checking tag: ${{ steps.tag-name.outputs.tag_name }}"
 
@@ -130,7 +129,7 @@ jobs:
 
       - name: Check if the plugin has front-end assets
         shell: bash
-        if: ${{ steps.extract-version.outputs.package_version }} != false
+        if: steps.extract-version.outputs.package_version != 'false'
         id: has_node_assets
         run: |
           [[ -f package.json ]] && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
@@ -140,20 +139,20 @@ jobs:
   # production-built would be the built branch that gets pushed to.
   build-branch-and-release:
     needs: extract-version
-    if: ${{ needs.extract-version.outputs.is_built_branch == false }} && ${{ needs.extract-version.outputs.has_node_assets }} && ${{ needs.extract-version.outputs.branch != false }} && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+    if: needs.extract-version.outputs.is_built_branch == 'false' && needs.extract-version.outputs.has_node_assets == 'true' && needs.extract-version.outputs.branch != 'false' && github.repository != 'alleyinteractive/create-wordpress-plugin'
     runs-on: ubuntu-latest
     env:
       BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
-      CURRENT_BRANCH: ${{ needs.extract-version.outputs.branch }}
-      VERSION_NAME: ${{ needs.extract-version.outputs.package_version }}
-      VERSION_TAG: ${{ needs.extract-version.outputs.tag_name }}
+      CURRENT_BRANCH: '${{ needs.extract-version.outputs.branch }}'
+      VERSION_NAME: '${{ needs.extract-version.outputs.package_version }}'
+      VERSION_TAG: '${{ needs.extract-version.outputs.tag_name }}'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: Install dependencies
-        if: ${{ inputs.composer_install }}
+        if: inputs.composer_install
         uses: php-actions/composer@v6
         with:
           php_version: ${{ inputs.php }}
@@ -197,7 +196,7 @@ jobs:
           git push --force -u origin "${BUILT_BRANCH}"
 
       - name: Create tag and release for built branch
-        if: ${{ needs.extract-version.outputs.tag_exists == false }}
+        if: needs.extract-version.outputs.package_version != 'false' && needs.extract-version.outputs.tag_exists == 'false'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -218,7 +217,7 @@ jobs:
   # and release that will be pushed to GitHub.
   # create-release:
   #   needs: extract-version
-  #   if: ${{ needs.extract-version.outputs.is_built_branch }} == true && ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != false && ${{ needs.extract-version.outputs.has_node_assets }} == true && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+  #   if: ${{ needs.extract-version.outputs.is_built_branch }} == 'true' && ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
   #   runs-on: ubuntu-latest
   #   env:
   #     RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}-${{ github.run_number }}"

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -130,7 +130,7 @@ jobs:
   # For the *-built branch, build the assets and push them to the corresponding
   # built branch. For example, production would be the current branch and
   # production-built would be the built branch that gets pushed to.
-  build-branch:
+  build-branch-and-release:
     needs: extract-version
     if: ${{ needs.extract-version.outputs.is_built_branch }} == 'false' && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -137,6 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
+      CREATING_RELEASE: ${{ needs.extract-version.outputs.package_version != 'false' && needs.extract-version.outputs.tag_exists == 'false' && 'true' || 'false' }}
       CURRENT_BRANCH: '${{ needs.extract-version.outputs.branch }}'
       VERSION_NAME: '${{ needs.extract-version.outputs.package_version }}'
       VERSION_TAG: '${{ needs.extract-version.outputs.tag_name }}'
@@ -186,7 +187,16 @@ jobs:
 
           git checkout -b $BUILT_BRANCH
 
-          git add -A && git commit -m "Built changes from $CURRENT_BRANCH: $GITHUB_SHA"
+          git add -A
+
+          echo "CREATING_RELEASE: $CREATING_RELEASE"
+
+          if [[ $CREATING_RELEASE == "true" ]]; then
+            git commit -m "Releasing $VERSION_TAG with built changes from $CURRENT_BRANCH $GITHUB_SHA"
+          else
+            git commit -m "Built changes from $CURRENT_BRANCH $GITHUB_SHA"
+          fi
+
           git push --force -u origin "${BUILT_BRANCH}"
 
       - name: Create tag and release for built branch

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -84,8 +84,10 @@ jobs:
 
           if [ $PACKAGE_VERSION = "null" ] || [ -z $PACKAGE_VERSION ]; then
             echo "package_version=false" >> $GITHUB_OUTPUT
+            echo "package_version is false 🚧" # DEBUG
           else
             echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+            echo "package_version is $PACKAGE_VERSION ✅" # DEBUG
           fi
 
       - name: Extract branch name
@@ -140,6 +142,10 @@ jobs:
       VERSION_NAME: ${{ needs.extract-version.outputs.package_version }}
       VERSION_TAG: ${{ needs.extract-version.outputs.tag_name }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
       - name: Install dependencies
         if: ${{ inputs.composer_install }}
         uses: php-actions/composer@v6

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
-      CREATING_RELEASE: ${{ needs.extract-version.outputs.package_version != 'false' && needs.extract-version.outputs.tag_exists == 'false' && 'true' || 'false' }}
+      CREATING_RELEASE: ${{ needs.extract-version.outputs.package_version != 'false' && needs.extract-version.outputs.tag_exists == 'false' && 'true' }}
       CURRENT_BRANCH: '${{ needs.extract-version.outputs.branch }}'
       VERSION_NAME: '${{ needs.extract-version.outputs.package_version }}'
       VERSION_TAG: '${{ needs.extract-version.outputs.tag_name }}'
@@ -189,27 +189,20 @@ jobs:
 
           git add -A
 
-          echo "CREATING_RELEASE: $CREATING_RELEASE"
-
           if [[ $CREATING_RELEASE == "true" ]]; then
-            git commit -m "Releasing $VERSION_TAG with built changes from $CURRENT_BRANCH $GITHUB_SHA"
+            git commit -m "Built changes for $VERSION_TAG from $CURRENT_BRANCH $GITHUB_SHA"
           else
             git commit -m "Built changes from $CURRENT_BRANCH $GITHUB_SHA"
           fi
 
           git push --force -u origin "${BUILT_BRANCH}"
 
-      - name: Create tag and release for built branch
+      - name: Create release for built branch
         if: needs.extract-version.outputs.package_version != 'false' && needs.extract-version.outputs.tag_exists == 'false'
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # echo "Creating tag $VERSION_TAG for $BUILT_BRANCH..."
-          # git tag -a $VERSION_TAG -m "Release $VERSION_TAG" $BUILT_BRANCH
-          # git push origin $VERSION_TAG
-
-          # Create the GitHub release
           if [[ $DRAFT_RELEASE == "true" ]]; then
             gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --latest
           else

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -200,15 +200,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Creating tag $VERSION_TAG for $BUILT_BRANCH..."
-          git tag -a $VERSION_TAG -m "Release $VERSION_TAG" $BUILT_BRANCH
-          git push origin $VERSION_TAG
+          # echo "Creating tag $VERSION_TAG for $BUILT_BRANCH..."
+          # git tag -a $VERSION_TAG -m "Release $VERSION_TAG" $BUILT_BRANCH
+          # git push origin $VERSION_TAG
 
           # Create the GitHub release
           if [[ $DRAFT_RELEASE == "true" ]]; then
-            gh release create $VERSION_TAG -t "$VERSION_TAG" --generate-notes -d --verify-tag --latest
+            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --verify-tag --latest
           else
-            gh release create $VERSION_TAG -t "$VERSION_TAG" --generate-notes --verify-tag --latest
+            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes --verify-tag --latest
           fi
 
 

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -127,9 +127,8 @@ jobs:
             echo "Tag exists!!"
           fi
 
-      - name: Check if the plugin has front-end assets
+      - name: Check if the project has front-end assets
         shell: bash
-        if: steps.extract-version.outputs.package_version != 'false'
         id: has_node_assets
         run: |
           [[ -f package.json ]] && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -35,6 +35,7 @@ jobs:
       has_node_assets: ${{ steps.has_node_assets.outputs.exists }}
       is_built_branch: ${{ steps.is-built-branch.outputs.is_built_branch }}
       package_version: ${{ steps.extract-version.outputs.package_version }}
+      previous_tag_version: ${{ steps.previous-tag-version.outputs.previous_tag_version }}
       tag_exists: ${{ steps.check-tag.outputs.tag_exists }}
       tag_name: ${{ steps.tag-name.outputs.tag_name }}
     if: github.repository != 'alleyinteractive/create-wordpress-plugin'
@@ -121,6 +122,22 @@ jobs:
             echo "tag_exists=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Extract previous tag version
+        id: previous-tag-version
+        if: steps.check-tag.outputs.tag_exists == 'false' && steps.extract-version.outputs.package_version != 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get the release tag for comparison using the gh release command
+          PREVIOUS_TAG=$(gh release list --limit 1 | grep -Eo "v[0-9]+\.[0-9]+\.[0-9]+" | head -1)
+
+          # If there is no previous tag, then we can't compare
+          if [ -z "$PREVIOUS_TAG" ]; then
+            echo "previous_tag_version=false" >> $GITHUB_OUTPUT
+          else
+            echo "previous_tag_version=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+          fi
+
       - name: Check if the project has front-end assets
         shell: bash
         id: has_node_assets
@@ -139,6 +156,7 @@ jobs:
       BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
       CREATING_RELEASE: ${{ needs.extract-version.outputs.package_version != 'false' && needs.extract-version.outputs.tag_exists == 'false' && 'true' }}
       CURRENT_BRANCH: '${{ needs.extract-version.outputs.branch }}'
+      PREVIOUS_TAG_VERSION: '${{ needs.extract-version.outputs.previous_tag_version }}'
       VERSION_NAME: '${{ needs.extract-version.outputs.package_version }}'
       VERSION_TAG: '${{ needs.extract-version.outputs.tag_name }}'
     steps:
@@ -203,8 +221,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [[ $DRAFT_RELEASE == "true" ]]; then
-            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --latest
+          echo "PREVIOUS_TAG_VERSION: $PREVIOUS_TAG_VERSION"
+
+          if [ "$PREVIOUS_TAG_VERSION" == "false" ]; then
+            if [[ $DRAFT_RELEASE == "true" ]]; then
+              gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --latest
+            else
+              gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes --latest
+            fi
           else
-            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes --latest
+            if [[ $DRAFT_RELEASE == "true" ]]; then
+              gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --latest --notes-start-tag "$PREVIOUS_TAG_VERSION"
+            else
+              gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes --latest --notes-start-tag "$PREVIOUS_TAG_VERSION"
+            fi
           fi

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -11,8 +11,13 @@ on:
       composer_install:
         description: 'Whether or not to run composer install'
         required: false
-        default: false
+        default: true
         type: boolean
+      npm_command:
+        description: 'The npm command to run that will build the assets'
+        required: false
+        default: 'build'
+        type: string
       php:
         default: "8.1"
         required: false
@@ -26,7 +31,9 @@ jobs:
   extract-version:
     runs-on: ubuntu-latest
     outputs:
+      branch: ${{ steps.branch-name.outputs.branch }}
       has_node_assets: ${{ steps.has_node_assets.outputs.exists }}
+      is_built_branch: ${{ steps.is-built-branch.outputs.is_built_branch }}
       package_version: ${{ steps.extract-version.outputs.package_version }}
       tag_exists: ${{ steps.check-tag.outputs.tag_exists }}
       tag_name: ${{ steps.tag-name.outputs.tag_name }}
@@ -81,6 +88,23 @@ jobs:
             echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
           fi
 
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        id: branch-name
+
+      - name: Check if this is the built branch
+        id: is-built-branch
+        shell: bash
+        run: |
+          if [[ ${{ steps.branch-name.outputs.branch }} =~ -built$ ]]; then
+            echo "is_built_branch=true" >> $GITHUB_OUTPUT
+            echo "Is built branch 🚧"
+          else
+            echo "is_built_branch=false" >> $GITHUB_OUTPUT
+            echo "Is not built branch ✅"
+          fi
+
       - name: Compile the tag name from the version
         id: tag-name
         if: ${{ steps.extract-version.outputs.package_version }} != 'false'
@@ -103,25 +127,19 @@ jobs:
         run: |
           [[ -f package.json ]] && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
 
-  build-and-release:
+  # For the *-built branch, build the assets and push them to the corresponding
+  # built branch. For example, production would be the current branch and
+  # production-built would be the built branch that gets pushed to.
+  build-branch:
     needs: extract-version
-    if : ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+    if: ${{ needs.extract-version.outputs.is_built_branch }} == 'false' && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
     runs-on: ubuntu-latest
     env:
-      RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}-${{ github.run_number }}"
+      BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
+      CURRENT_BRANCH: ${{ needs.extract-version.outputs.branch }}
       VERSION_NAME: ${{ needs.extract-version.outputs.package_version }}
       VERSION_TAG: ${{ needs.extract-version.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-
-      - name: Debug variables
-        run: |
-          echo "RELEASE_BRANCH=$RELEASE_BRANCH"
-          echo "VERSION_NAME=$VERSION_NAME"
-          echo "VERSION_TAG=$VERSION_TAG"
-
       - name: Install dependencies
         if: ${{ inputs.composer_install }}
         uses: php-actions/composer@v6
@@ -140,12 +158,11 @@ jobs:
           [ -f package-lock.json ] && npm ci || npm i
 
       - name: Run npm build
-        run: npm run build
+        run: npm run ${{ inputs.npm_command }}
 
-      - name: Push to release branch
+      - name: Push to *-built branch
         shell: bash
         env:
-          DRAFT_RELEASE: ${{ inputs.draft }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
@@ -153,6 +170,7 @@ jobs:
 
           rm -rf .gitignore docker_tag output.log .github
 
+          # Clear out the .gitignore file if .deployignore exists
           if [[ -e "$GITHUB_WORKSPACE/.deployignore" ]]; then
             mv .deployignore .gitignore
           elif [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
@@ -161,17 +179,20 @@ jobs:
 
           git ls-files -i -c --exclude-standard | xargs git rm --cached
 
-          git checkout -b $RELEASE_BRANCH
+          git checkout -b $BUILT_BRANCH
 
           git add -A && git commit -m "Built changes for $VERSION_TAG"
-          git push --force -u origin "${RELEASE_BRANCH}"
+          git push --force -u origin "${BUILT_BRANCH}"
 
-          # Create a tag from the release branch
-          git tag -a $VERSION_TAG -m "Release $VERSION_TAG"
+      - name: Create tag and release for built branch
+        if: ${{ needs.extract-version.outputs.tag_exists }} == 'false'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Creating tag $VERSION_TAG for $BUILT_BRANCH..."
+          git tag -a $VERSION_TAG -m "Release $VERSION_TAG" $BUILT_BRANCH
           git push origin $VERSION_TAG
-
-          # Delete the release branch
-          git push origin --delete $RELEASE_BRANCH
 
           # Create the GitHub release
           if [[ $DRAFT_RELEASE == "true" ]]; then
@@ -179,3 +200,83 @@ jobs:
           else
             gh release create $VERSION_TAG -t "$VERSION_TAG" --generate-notes --verify-tag --latest
           fi
+
+
+  # For a push to a built branch (branch that ends with -built), create a tag
+  # and release that will be pushed to GitHub.
+  # create-release:
+  #   needs: extract-version
+  #   if: ${{ needs.extract-version.outputs.is_built_branch }} == 'true' && ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+  #   runs-on: ubuntu-latest
+  #   env:
+  #     RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}-${{ github.run_number }}"
+  #     VERSION_NAME: ${{ needs.extract-version.outputs.package_version }}
+  #     VERSION_TAG: ${{ needs.extract-version.outputs.tag_name }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 2
+
+  #     - name: Debug variables
+  #       run: |
+  #         echo "RELEASE_BRANCH=$RELEASE_BRANCH"
+  #         echo "VERSION_NAME=$VERSION_NAME"
+  #         echo "VERSION_TAG=$VERSION_TAG"
+
+  #     # - name: Install dependencies
+  #     #   if: ${{ inputs.composer_install }}
+  #     #   uses: php-actions/composer@v6
+  #     #   with:
+  #     #     php_version: ${{ inputs.php }}
+  #     #     version: 2
+  #     #     args: --prefer-dist --no-dev
+
+  #     # - name: Setup Node
+  #     #   uses: actions/setup-node@v4
+  #     #   with:
+  #     #     node-version: ${{ inputs.node }}
+
+  #     # - name: Install node dependencies
+  #     #   run: |
+  #     #     [ -f package-lock.json ] && npm ci || npm i
+
+  #     # - name: Run npm build
+  #     #   run: npm run ${{ inputs.npm_command }}
+
+  #     - name: Push to release branch
+  #       shell: bash
+  #       env:
+  #         DRAFT_RELEASE: ${{ inputs.draft }}
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+  #         git config --global user.name "$GITHUB_ACTOR"
+
+  #         rm -rf .gitignore docker_tag output.log .github
+
+  #         if [[ -e "$GITHUB_WORKSPACE/.deployignore" ]]; then
+  #           mv .deployignore .gitignore
+  #         elif [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
+  #           mv .distignore .gitignore
+  #         fi
+
+  #         git ls-files -i -c --exclude-standard | xargs git rm --cached
+
+  #         git checkout -b $RELEASE_BRANCH
+
+  #         git add -A && git commit -m "Built changes for $VERSION_TAG"
+  #         git push --force -u origin "${RELEASE_BRANCH}"
+
+  #         # Create a tag from the release branch
+  #         git tag -a $VERSION_TAG -m "Release $VERSION_TAG"
+  #         git push origin $VERSION_TAG
+
+  #         # Delete the release branch
+  #         git push origin --delete $RELEASE_BRANCH
+
+  #         # Create the GitHub release
+  #         if [[ $DRAFT_RELEASE == "true" ]]; then
+  #           gh release create $VERSION_TAG -t "$VERSION_TAG" --generate-notes -d --verify-tag --latest
+  #         else
+  #           gh release create $VERSION_TAG -t "$VERSION_TAG" --generate-notes --verify-tag --latest
+  #         fi

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -116,11 +116,15 @@ jobs:
         id: check-tag
         if: ${{ steps.tag-name.outputs.tag_name }}
         run: |
+          echo "Checking tag: ${{ steps.tag-name.outputs.tag_name }}"
+
           # Check if the tag exists
           if [ -z "$(git tag -l ${{ steps.tag-name.outputs.tag_name }})" ]; then
             echo "tag_exists=false" >> $GITHUB_OUTPUT
+            echo "Tag does not exist ✅"
           else
             echo "tag_exists=true" >> $GITHUB_OUTPUT
+            echo "Tag exists!!"
           fi
 
       - name: Check if the plugin has front-end assets

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -96,7 +96,7 @@ jobs:
         id: branch-name
 
       - name: Check if this is the built branch
-        if: ${{ steps.extract-version.outputs.package_version != 'false' }}
+        if: ${{ steps.extract-version.outputs.package_version != false }}
         id: is-built-branch
         shell: bash
         run: |
@@ -110,12 +110,12 @@ jobs:
 
       - name: Compile the tag name from the version
         id: tag-name
-        if: ${{ steps.extract-version.outputs.package_version != 'false' }}
+        if: ${{ steps.extract-version.outputs.package_version != false }}
         run: echo "tag_name=v${{ steps.extract-version.outputs.package_version }}" >> $GITHUB_OUTPUT
 
       - name: Check if the version already exists as a tag
         id: check-tag
-        if: ${{ steps.extract-version.outputs.package_version != 'false' }} && ${{ steps.tag-name.outputs.tag_name }}
+        if: ${{ steps.extract-version.outputs.package_version != false }} && ${{ steps.tag-name.outputs.tag_name }}
         run: |
           echo "Checking tag: ${{ steps.tag-name.outputs.tag_name }}"
 
@@ -130,7 +130,7 @@ jobs:
 
       - name: Check if the plugin has front-end assets
         shell: bash
-        if: ${{ steps.extract-version.outputs.package_version }} != 'false'
+        if: ${{ steps.extract-version.outputs.package_version }} != false
         id: has_node_assets
         run: |
           [[ -f package.json ]] && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
@@ -140,7 +140,7 @@ jobs:
   # production-built would be the built branch that gets pushed to.
   build-branch-and-release:
     needs: extract-version
-    if: ${{ needs.extract-version.outputs.is_built_branch == 'false' }} && ${{ needs.extract-version.outputs.has_node_assets == 'true' }} && ${{ needs.extract-version.outputs.branch != 'false' }} && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+    if: ${{ needs.extract-version.outputs.is_built_branch == false }} && ${{ needs.extract-version.outputs.has_node_assets }} && ${{ needs.extract-version.outputs.branch != false }} && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
     runs-on: ubuntu-latest
     env:
       BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
@@ -197,7 +197,7 @@ jobs:
           git push --force -u origin "${BUILT_BRANCH}"
 
       - name: Create tag and release for built branch
-        if: ${{ needs.extract-version.outputs.tag_exists == 'false' }}
+        if: ${{ needs.extract-version.outputs.tag_exists == false }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -218,7 +218,7 @@ jobs:
   # and release that will be pushed to GitHub.
   # create-release:
   #   needs: extract-version
-  #   if: ${{ needs.extract-version.outputs.is_built_branch }} == 'true' && ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+  #   if: ${{ needs.extract-version.outputs.is_built_branch }} == true && ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != false && ${{ needs.extract-version.outputs.has_node_assets }} == true && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
   #   runs-on: ubuntu-latest
   #   env:
   #     RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}-${{ github.run_number }}"

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Extract version
         id: extract-version
@@ -148,7 +148,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Install dependencies
         if: inputs.composer_install

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -141,9 +141,6 @@ jobs:
         run: |
           [[ -f package.json ]] && echo "exists=true" >> $GITHUB_OUTPUT || echo "exists=false" >> $GITHUB_OUTPUT
 
-  # For the *-built branch, build the assets and push them to the corresponding
-  # built branch. For example, production would be the current branch and
-  # production-built would be the built branch that gets pushed to.
   build-branch-and-release:
     name: Build assets and push to built branch
     needs: extract-version

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -84,10 +84,8 @@ jobs:
 
           if [ $PACKAGE_VERSION = "null" ] || [ -z $PACKAGE_VERSION ]; then
             echo "package_version=false" >> $GITHUB_OUTPUT
-            echo "package_version is false 🚧" # DEBUG
           else
             echo "package_version=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-            echo "package_version is $PACKAGE_VERSION ✅" # DEBUG
           fi
 
       - name: Extract branch name
@@ -101,10 +99,8 @@ jobs:
         run: |
           if [[ ${{ steps.branch-name.outputs.branch }} =~ -built$ ]]; then
             echo "is_built_branch=true" >> $GITHUB_OUTPUT
-            echo "Is built branch 🚧"
           else
             echo "is_built_branch=false" >> $GITHUB_OUTPUT
-            echo "Is not built branch ✅"
           fi
 
       - name: Compile the tag name from the version
@@ -121,10 +117,8 @@ jobs:
           # Check if the tag exists
           if [ -z "$(git tag -l ${{ steps.tag-name.outputs.tag_name }})" ]; then
             echo "tag_exists=false" >> $GITHUB_OUTPUT
-            echo "Tag does not exist ✅"
           else
             echo "tag_exists=true" >> $GITHUB_OUTPUT
-            echo "Tag exists!!"
           fi
 
       - name: Check if the project has front-end assets
@@ -210,83 +204,3 @@ jobs:
           else
             gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes --verify-tag --latest
           fi
-
-
-  # For a push to a built branch (branch that ends with -built), create a tag
-  # and release that will be pushed to GitHub.
-  # create-release:
-  #   needs: extract-version
-  #   if: ${{ needs.extract-version.outputs.is_built_branch }} == 'true' && ${{ needs.extract-version.outputs.tag_exists }} && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
-  #   runs-on: ubuntu-latest
-  #   env:
-  #     RELEASE_BRANCH: "release/${{ needs.extract-version.outputs.tag_name }}-${{ github.run_number }}"
-  #     VERSION_NAME: ${{ needs.extract-version.outputs.package_version }}
-  #     VERSION_TAG: ${{ needs.extract-version.outputs.tag_name }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 2
-
-  #     - name: Debug variables
-  #       run: |
-  #         echo "RELEASE_BRANCH=$RELEASE_BRANCH"
-  #         echo "VERSION_NAME=$VERSION_NAME"
-  #         echo "VERSION_TAG=$VERSION_TAG"
-
-  #     # - name: Install dependencies
-  #     #   if: ${{ inputs.composer_install }}
-  #     #   uses: php-actions/composer@v6
-  #     #   with:
-  #     #     php_version: ${{ inputs.php }}
-  #     #     version: 2
-  #     #     args: --prefer-dist --no-dev
-
-  #     # - name: Setup Node
-  #     #   uses: actions/setup-node@v4
-  #     #   with:
-  #     #     node-version: ${{ inputs.node }}
-
-  #     # - name: Install node dependencies
-  #     #   run: |
-  #     #     [ -f package-lock.json ] && npm ci || npm i
-
-  #     # - name: Run npm build
-  #     #   run: npm run ${{ inputs.npm_command }}
-
-  #     - name: Push to release branch
-  #       shell: bash
-  #       env:
-  #         DRAFT_RELEASE: ${{ inputs.draft }}
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #       run: |
-  #         git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-  #         git config --global user.name "$GITHUB_ACTOR"
-
-  #         rm -rf .gitignore docker_tag output.log .github
-
-  #         if [[ -e "$GITHUB_WORKSPACE/.deployignore" ]]; then
-  #           mv .deployignore .gitignore
-  #         elif [[ -e "$GITHUB_WORKSPACE/.distignore" ]]; then
-  #           mv .distignore .gitignore
-  #         fi
-
-  #         git ls-files -i -c --exclude-standard | xargs git rm --cached
-
-  #         git checkout -b $RELEASE_BRANCH
-
-  #         git add -A && git commit -m "Built changes for $VERSION_TAG"
-  #         git push --force -u origin "${RELEASE_BRANCH}"
-
-  #         # Create a tag from the release branch
-  #         git tag -a $VERSION_TAG -m "Release $VERSION_TAG"
-  #         git push origin $VERSION_TAG
-
-  #         # Delete the release branch
-  #         git push origin --delete $RELEASE_BRANCH
-
-  #         # Create the GitHub release
-  #         if [[ $DRAFT_RELEASE == "true" ]]; then
-  #           gh release create $VERSION_TAG -t "$VERSION_TAG" --generate-notes -d --verify-tag --latest
-  #         else
-  #           gh release create $VERSION_TAG -t "$VERSION_TAG" --generate-notes --verify-tag --latest
-  #         fi

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -96,7 +96,7 @@ jobs:
         id: branch-name
 
       - name: Check if this is the built branch
-        if: ${{ steps.extract-version.outputs.package_version }} != 'false'
+        if: ${{ steps.extract-version.outputs.package_version != 'false' }}
         id: is-built-branch
         shell: bash
         run: |
@@ -110,12 +110,12 @@ jobs:
 
       - name: Compile the tag name from the version
         id: tag-name
-        if: ${{ steps.extract-version.outputs.package_version }} != 'false'
+        if: ${{ steps.extract-version.outputs.package_version != 'false' }}
         run: echo "tag_name=v${{ steps.extract-version.outputs.package_version }}" >> $GITHUB_OUTPUT
 
       - name: Check if the version already exists as a tag
         id: check-tag
-        if: ${{ steps.extract-version.outputs.package_version }} != 'false' && ${{ steps.tag-name.outputs.tag_name }}
+        if: ${{ steps.extract-version.outputs.package_version != false }} && ${{ steps.tag-name.outputs.tag_name }}
         run: |
           echo "Checking tag: ${{ steps.tag-name.outputs.tag_name }}"
 
@@ -140,7 +140,7 @@ jobs:
   # production-built would be the built branch that gets pushed to.
   build-branch-and-release:
     needs: extract-version
-    if: ${{ needs.extract-version.outputs.is_built_branch }} == 'false' && ${{ needs.extract-version.outputs.package_version }} != 'false' && ${{ needs.extract-version.outputs.has_node_assets }} == 'true' && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+    if: ${{ needs.extract-version.outputs.is_built_branch == 'false' }} && ${{ needs.extract-version.outputs.package_version != 'false' }} && ${{ needs.extract-version.outputs.has_node_assets == true }} && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
     runs-on: ubuntu-latest
     env:
       BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
@@ -197,7 +197,7 @@ jobs:
           git push --force -u origin "${BUILT_BRANCH}"
 
       - name: Create tag and release for built branch
-        if: ${{ needs.extract-version.outputs.tag_exists }} == 'false'
+        if: ${{ needs.extract-version.outputs.tag_exists == false }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Check if the version already exists as a tag
         id: check-tag
-        if: ${{ steps.extract-version.outputs.package_version != false }} && ${{ steps.tag-name.outputs.tag_name }}
+        if: ${{ steps.extract-version.outputs.package_version != 'false' }} && ${{ steps.tag-name.outputs.tag_name }}
         run: |
           echo "Checking tag: ${{ steps.tag-name.outputs.tag_name }}"
 
@@ -140,7 +140,7 @@ jobs:
   # production-built would be the built branch that gets pushed to.
   build-branch-and-release:
     needs: extract-version
-    if: ${{ needs.extract-version.outputs.is_built_branch == 'false' }} && ${{ needs.extract-version.outputs.package_version != 'false' }} && ${{ needs.extract-version.outputs.has_node_assets == true }} && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
+    if: ${{ needs.extract-version.outputs.is_built_branch == 'false' }} && ${{ needs.extract-version.outputs.has_node_assets == 'true' }} && ${{ needs.extract-version.outputs.branch != 'false' }} && ${{ github.repository != 'alleyinteractive/create-wordpress-plugin' }}
     runs-on: ubuntu-latest
     env:
       BUILT_BRANCH: '${{ needs.extract-version.outputs.branch }}-built'
@@ -172,7 +172,7 @@ jobs:
       - name: Run npm build
         run: npm run ${{ inputs.npm_command }}
 
-      - name: Push to *-built branch
+      - name: Push to ${{ needs.extract-version.outputs.branch }}-built branch
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -193,11 +193,11 @@ jobs:
 
           git checkout -b $BUILT_BRANCH
 
-          git add -A && git commit -m "Built changes for $VERSION_TAG"
+          git add -A && git commit -m "Built changes from $CURRENT_BRANCH"
           git push --force -u origin "${BUILT_BRANCH}"
 
       - name: Create tag and release for built branch
-        if: ${{ needs.extract-version.outputs.tag_exists == false }}
+        if: ${{ needs.extract-version.outputs.tag_exists == 'false' }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/built-release.yml
+++ b/.github/workflows/built-release.yml
@@ -131,6 +131,7 @@ jobs:
   # built branch. For example, production would be the current branch and
   # production-built would be the built branch that gets pushed to.
   build-branch-and-release:
+    name: Build assets and push to built branch
     needs: extract-version
     if: needs.extract-version.outputs.is_built_branch == 'false' && needs.extract-version.outputs.has_node_assets == 'true' && needs.extract-version.outputs.branch != 'false' && github.repository != 'alleyinteractive/create-wordpress-plugin'
     runs-on: ubuntu-latest
@@ -200,7 +201,7 @@ jobs:
 
           # Create the GitHub release
           if [[ $DRAFT_RELEASE == "true" ]]; then
-            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --verify-tag --latest
+            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes -d --latest
           else
-            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes --verify-tag --latest
+            gh release create $VERSION_TAG --target "$BUILT_BRANCH" -t "$VERSION_TAG" --generate-notes --latest
           fi

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -10,7 +10,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,7 +11,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    if: ${{ github.actor == 'dependabot[bot]' }}
+    if: github.actor == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: metadata

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         uses: styfle/cancel-workflow-action@0.12.0
         with:
           access_token: ${{ github.token }}

--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Cancel previous runs of this workflow (pull requests only)
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request'
         uses: styfle/cancel-workflow-action@0.12.0
         with:
           access_token: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
 ### Built Releases
 
 Create built releases of a project based on the WordPress plugin `Version`
-header in your main plugin file and then falls back to the `version` property in
+header in your main plugin file and then falling back to the `version` property in
 either `composer.json` or `package.json`. When the version is updated in either
 file, the action will build the project, push a new tag up with the version, and
 create a release. Optionally, the release can be drafted or published.

--- a/README.md
+++ b/README.md
@@ -72,14 +72,23 @@ jobs:
 ### Built Releases
 
 Create built releases of a project based on the WordPress plugin `Stable Tag`
-header and falling back to the `version` property in either `composer.json` or
-`package.json`. When the version is updated in either file, the action
-will build the project, push a new tag up with the version, and create a
-release. Optionally, the release can be drafted or published.
+header and falls back to the `version` property in either `composer.json` or
+`package.json`. When the version is updated in either file, the action will
+build the project, push a new tag up with the version, and create a release.
+Optionally, the release can be drafted or published.
 
 The most common use of this workflow is for WordPress plugins or other packages
 that require built assets (such as ones from Webpack or Gulp) to be included to
 work but we don't want to include those assets in version control.
+
+When the plugin's version is incremented on
+`alleyinteractive/create-wordpress-plugin`-based plugins via `npm run release`,
+the action will push a built version of the plugin to the `*-built` branch and
+then create a release with the built assets. If the plugin's version was not
+incremented, the action will still push the latest changes to the `*-built`
+branch but will not create a release. This does mirror the
+[Built Branch](#built-branch) workflow but is more flexible and allows for
+publishing releases.
 
 #### Inputs
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ jobs:
 
 ### Built Releases
 
-Create built releases of a project based on the WordPress plugin `Stable Tag`
-header and falls back to the `version` property in either `composer.json` or
-`package.json`. When the version is updated in either file, the action will
-build the project, push a new tag up with the version, and create a release.
-Optionally, the release can be drafted or published.
+Create built releases of a project based on the WordPress plugin `Version`
+header in your main plugin file and then falls back to the `version` property in
+either `composer.json` or `package.json`. When the version is updated in either
+file, the action will build the project, push a new tag up with the version, and
+create a release. Optionally, the release can be drafted or published.
 
 The most common use of this workflow is for WordPress plugins or other packages
 that require built assets (such as ones from Webpack or Gulp) to be included to


### PR DESCRIPTION
Restructure the `built-release.yml` action to fix the issues in #61.

Instead of pushing a release to an orphaned release branch (`release/vX.X.X-TIMESTAMP`) we'll push to the built version of our production branch (`develop-built`, `production-built`, etc.) and then use that to create a release/tag from. This allows us to have a built version of the production branch that can be used externally and reuse the same branch for releases to prevent isolated commits. 

This also fixes the issue with the `--generate-notes` argument that we pass to `gh release create` to properly create release notes from the previous release (1.0.0 -> 2.0.0).

I tested this updated workflow in https://github.com/alleyinteractive/github-workflow-test/releases to ensure that releases generated are sequentially generated and not using a broken changelog link as @renatonascalves noted in #61.

Fixes #61 