### PR TITLE
Feature: support object cache services conditionally

### DIFF
--- a/.github/workflows/php-tests.yml
+++ b/.github/workflows/php-tests.yml
@@ -23,6 +23,10 @@ on:
         default: "ubuntu-latest"
         required: false
         type: string
+      object-cache:
+        default: ""
+        required: false
+        type: string
       dependency-versions:
         default: "locked"
         required: false
@@ -48,6 +52,18 @@ jobs:
         ports:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      # Include the below services conditionaly.
+      # The service will not start if the image is empty.
+      # See https://github.com/actions/runner/issues/822
+      redis:
+        image: ${{ ( inputs.object-cache == 'redis' ) && format('{0}:alpine', inputs.object-cache) || '' }}
+        ports:
+          - "6379:6379"
+        options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+      memcached:
+        image: ${{ ( inputs.object-cache == 'memcached' ) && format('{0}:alpine', inputs.object-cache) || '' }}
+        ports:
+          - "11211:11211"
     name: "phpunit ${{ inputs.php }} - ${{ inputs.wordpress }} - ${{ inputs.os }} - multisite: ${{ inputs.multisite }}"
     env:
       CACHEDIR: /tmp/test-cache

--- a/README.md
+++ b/README.md
@@ -387,6 +387,12 @@ tests.
 - Accepts a boolean.
 - Defaults to `false`.
 
+##### `object-cache`
+
+- Specify the object to use.
+- Valid values are `memcached` or `redis`.
+- Defaults to not adding the service.
+
 #### `dependency-versions`
 
 - Allows you to select whether the job should install the locked, highest, or lowest versions of Composer dependencies.


### PR DESCRIPTION
Supports `redis` and `memcached`.

The way I'm adding the services conditionally is necessary until Github suports it properly. See https://github.com/actions/runner/issues/822

I tested this in two projects.

Here is one example where I used `memcached` to skip some unit tests: https://github.com/alleyinteractive/wp-404-caching/actions/runs/8515841284/job/23323992799

Here is another one to test `redis` and `memcached`: https://github.com/alleyinteractive/mantle-framework/actions/runs/8515744271/job/23323736947

See how [this test](https://github.com/alleyinteractive/mantle-framework/actions/runs/8311502406/job/22745265062) works without redis.

![CleanShot 2024-04-01 at 22 07 10@2x](https://github.com/alleyinteractive/.github/assets/19148962/f619b1c1-324a-459d-ab5f-c0af8a26eca0)

fixes #55 
fixes #46 