### PR TITLE
Use issue types for templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: "Report something that's broken or otherwise not working as expected."
 labels: ["bug"]
+type: "Bug"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature or Enhancement Request
 description: Request a new feature or enhancement
 labels: ["enhancement"]
+type: "Feature"
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Will require verification after merging. The syntax matches https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms