### PR TITLE
Issue-95: Update Issue Templates to Use Issue Types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: "Report something that's broken or otherwise not working as expected."
-labels: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_update_request.yml
@@ -1,5 +1,6 @@
 name: Documentation Update
 description: "Report something in the project documentation that is incorrect or otherwise inaccurate."
+type: Task
 labels: ["documentation"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature or Enhancement Request
 description: Request a new feature or enhancement
-labels: ["enhancement"]
+type: Feature
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/for-discussion.yml
+++ b/.github/ISSUE_TEMPLATE/for-discussion.yml
@@ -1,11 +1,12 @@
 name: For Discussion
 description: Open a topic for discussion
+type: Feature
 labels: ["discussion"]
 body:
   - type: markdown
     attributes:
       value: |
-        Before submitting your issue, please ensure that you have read our [Code of Conduct](https://github.com/alleyinteractive/.github/blob/main/CODE_OF_CONDUCT.md) and you have read through existing issues so as to avoid creating duplicates. 🙏 
+        Before submitting your issue, please ensure that you have read our [Code of Conduct](https://github.com/alleyinteractive/.github/blob/main/CODE_OF_CONDUCT.md) and you have read through existing issues so as to avoid creating duplicates. 🙏
 
   - type: textarea
     attributes:


### PR DESCRIPTION
### Summary

Fixes #95

This pull request updates the issue templates to use GitHub's new issue types instead of relying on labels. This ensures that issues are categorized correctly (e.g., Bug, Feature, Task) when created, without needing pre-set labels.

### Changes Made

- Updated issue templates to specify issue types instead of labels.
- Removed references to labels from the templates.

### Use Case

When a user creates a new issue in the repository, the issue will automatically be assigned the appropriate type (Bug, Feature, or Task) based on the updated templates, streamlining the issue creation process and adhering to GitHub's new features.

### Testing

- Verified that the updated issue templates correctly set the issue type when creating a new issue.
- Ensured no labels are pre-set during the issue creation process.

### Checklist

- [ ] All tests pass.
- [ ] Changes have been reviewed by at least one other contributor.
- [ ] Documentation has been updated if necessary.
