### PR TITLE
Issue-97: Automatically Add New Issues to Tech Department Project Board

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: "Report something that's broken or otherwise not working as expected."
 type: Bug
+projects: ["alleyinteractive/4"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/docs_update_request.yml
+++ b/.github/ISSUE_TEMPLATE/docs_update_request.yml
@@ -2,6 +2,7 @@ name: Documentation Update
 description: "Report something in the project documentation that is incorrect or otherwise inaccurate."
 type: Task
 labels: ["documentation"]
+projects: ["alleyinteractive/4"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: Feature or Enhancement Request
 description: Request a new feature or enhancement
 type: Feature
+projects: ["alleyinteractive/4"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/for-discussion.yml
+++ b/.github/ISSUE_TEMPLATE/for-discussion.yml
@@ -2,6 +2,7 @@ name: For Discussion
 description: Open a topic for discussion
 type: Feature
 labels: ["discussion"]
+projects: ["alleyinteractive/4"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
### Summary

Fixes #97. This pull request enables the configuration of issue templates to automatically add new issues to the Tech Department Project Board, provided the issue creator has access to the board. This ensures a streamlined process for Alley team members while avoiding errors for external users without board access.

### Description of Changes

- Configured the `projects` key in issue templates to ensure new issues are automatically added to the Tech Department Project Board when created by Alley team members.
- Verified that this setup does not cause errors for users outside the Alley team who do not have access to the board.

### Motivation and Context

This change addresses the need for a lightweight method to automatically organize and triage issues within the Tech Department Project Board. By implementing this feature, we reduce manual steps and improve efficiency for team members.

### Testing Instructions

1. Create a new issue as an Alley team member.
2. Verify that the issue is automatically added to the Tech Department Project Board.
3. Test the behavior with a user who does not have access to the board to ensure no errors occur.

### Screenshots (if applicable)

N/A

### Checklist

- [ ] Code has been tested locally.
- [ ] Documentation has been updated if necessary.
- [ ] All automated tests pass.
- [ ] Relevant reviewers have been assigned.

### Additional Notes

See the `projects` key documentation for reference: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax
